### PR TITLE
feat: Add configurable LLM providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ A modern TypeScript system that enables two different Large Language Models (Ope
 ## Features
 
 - **Full TypeScript implementation**: Type-safe conversation management with comprehensive interfaces
-- **Two-way LLM conversations**: OpenAI GPT and Anthropic Claude exchange messages with full context
+- **Configurable LLM providers**: Choose which provider (OpenAI/Anthropic) to use for LLM1 and LLM2
+- **Two-way LLM conversations**: Any combination of OpenAI GPT and Anthropic Claude can exchange messages
 - **Conversation history**: Maintains complete conversation context across all turns
 - **Comprehensive logging**: Detailed logs with timestamps and turn tracking
 - **JSON export**: Rich conversation data perfect for web applications and analysis
@@ -37,15 +38,25 @@ npm install
 
 2. Edit `config.env` and add your API keys:
    ```bash
-   # Required: Add your actual API keys
-   OPENAI_API_KEY="sk-your-actual-openai-key-here"
-   ANTHROPIC_API_KEY="sk-ant-your-actual-anthropic-key-here"
+   # LLM Provider Selection
+   # Choose which provider to use for each LLM (openai or anthropic)
+   LLM1_PROVIDER="openai"
+   LLM2_PROVIDER="anthropic"
    
-   # Optional: Customize models and settings
+   # OpenAI Configuration
+   OPENAI_API_KEY="sk-your-actual-openai-key-here"
    OPENAI_MODEL="gpt-4"
+   OPENAI_BASE_URL="https://api.openai.com/v1"
+   
+   # Anthropic Configuration
+   ANTHROPIC_API_KEY="sk-ant-your-actual-anthropic-key-here"
    ANTHROPIC_MODEL="claude-3-5-sonnet-20241022"
+   ANTHROPIC_BASE_URL="https://api.anthropic.com/v1"
+   
+   # Conversation Settings
    CONVERSATION_TOPIC="Discuss the future of artificial intelligence"
    MAX_TURNS="10"
+   DELAY_BETWEEN_MESSAGES="2"
    
    # Upload Settings (Optional)
    UPLOAD_ENABLED=true
@@ -54,6 +65,11 @@ npm install
    UPLOAD_MAX_RETRIES=3
    UPLOAD_RETRY_DELAY=1000
    ```
+   
+   **Note**: You can now configure which provider (OpenAI or Anthropic) to use for LLM1 and LLM2. For example:
+   - Set both to "anthropic" to have two Claude models talk
+   - Set both to "openai" to have two GPT models talk
+   - Mix and match as desired
 
 ### 3. Build the Project
 

--- a/config.env.example
+++ b/config.env.example
@@ -1,16 +1,19 @@
 # LLM Conversation Configuration
 # Copy this file to config.env and fill in your actual API keys
 
-# Required: API Keys
+# LLM Provider Selection
+# Choose which provider to use for each LLM (openai or anthropic)
+LLM1_PROVIDER="openai"
+LLM2_PROVIDER="anthropic"
+
+# OpenAI Configuration
 OPENAI_API_KEY="sk-your-actual-openai-key-here"
-ANTHROPIC_API_KEY="sk-ant-your-actual-anthropic-key-here"
-
-# Model Configuration
 OPENAI_MODEL="gpt-4"
-ANTHROPIC_MODEL="claude-3-5-sonnet-20241022"
-
-# API Base URLs
 OPENAI_BASE_URL="https://api.openai.com/v1"
+
+# Anthropic Configuration
+ANTHROPIC_API_KEY="sk-ant-your-actual-anthropic-key-here"
+ANTHROPIC_MODEL="claude-3-5-sonnet-20241022"
 ANTHROPIC_BASE_URL="https://api.anthropic.com/v1"
 
 # Conversation Settings

--- a/src/anthropic-handler.ts
+++ b/src/anthropic-handler.ts
@@ -4,8 +4,9 @@ import { Config, AnthropicResponse, TurnMetadata, AIHandlerResult } from './type
 import { Logger } from './logger';
 import { HistoryManager } from './history';
 import { withRetry, DEFAULT_RETRY_OPTIONS } from './retry-utils';
+import { LLMHandler } from './llm-handler-interface';
 
-export class AnthropicHandler {
+export class AnthropicHandler implements LLMHandler {
   private config: Config;
   private logger: Logger;
   private historyManager: HistoryManager;

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,18 +24,41 @@ export function loadConfig(): Config {
   
   // Validate required fields
   const requiredFields = [
-    'OPENAI_API_KEY',
-    'ANTHROPIC_API_KEY',
-    'OPENAI_MODEL',
-    'ANTHROPIC_MODEL',
-    'OPENAI_BASE_URL',
-    'ANTHROPIC_BASE_URL'
+    'LLM1_PROVIDER',
+    'LLM2_PROVIDER',
+    'CONVERSATION_TOPIC',
+    'MAX_TURNS',
+    'DELAY_BETWEEN_MESSAGES'
   ];
   
   for (const field of requiredFields) {
     if (!(config as any)[field]) {
       console.error(`Error: Missing required config field: ${field}`);
       process.exit(1);
+    }
+  }
+  
+  // Validate provider-specific fields
+  const providers = [
+    (config as any)['LLM1_PROVIDER'],
+    (config as any)['LLM2_PROVIDER']
+  ];
+  
+  for (const provider of providers) {
+    if (!provider) continue;
+    
+    const providerUpper = provider.toUpperCase();
+    const providerRequiredFields = [
+      `${providerUpper}_API_KEY`,
+      `${providerUpper}_MODEL`,
+      `${providerUpper}_BASE_URL`
+    ];
+    
+    for (const field of providerRequiredFields) {
+      if (!(config as any)[field]) {
+        console.error(`Error: Missing required config field: ${field} for provider: ${provider}`);
+        process.exit(1);
+      }
     }
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,11 +38,23 @@ export function loadConfig(): Config {
     }
   }
   
+  // Validate provider values
+  const validProviders = ['openai', 'anthropic'];
+  const llm1Provider = (config as any)['LLM1_PROVIDER'];
+  const llm2Provider = (config as any)['LLM2_PROVIDER'];
+  
+  if (!validProviders.includes(llm1Provider)) {
+    console.error(`Error: Invalid LLM1_PROVIDER value: ${llm1Provider}. Must be one of: ${validProviders.join(', ')}`);
+    process.exit(1);
+  }
+  
+  if (!validProviders.includes(llm2Provider)) {
+    console.error(`Error: Invalid LLM2_PROVIDER value: ${llm2Provider}. Must be one of: ${validProviders.join(', ')}`);
+    process.exit(1);
+  }
+  
   // Validate provider-specific fields
-  const providers = [
-    (config as any)['LLM1_PROVIDER'],
-    (config as any)['LLM2_PROVIDER']
-  ];
+  const providers = [llm1Provider, llm2Provider];
   
   for (const provider of providers) {
     if (!provider) continue;

--- a/src/conversation-adapter.ts
+++ b/src/conversation-adapter.ts
@@ -10,8 +10,7 @@ export class ConversationAdapter {
    * Maps an internal LLM identifier to its configured provider
    */
   static getProviderForLLM(llmId: LLMIdentifier, config: Config): LLMProvider {
-    const providerKey = llmId === 'llm1' ? 'LLM1_PROVIDER' : 'LLM2_PROVIDER';
-    const provider = (config as any)[providerKey] as LLMProvider;
+    const provider = llmId === 'llm1' ? config.LLM1_PROVIDER : config.LLM2_PROVIDER;
     
     if (!provider) {
       throw new Error(`Provider not configured for ${llmId}`);
@@ -31,8 +30,13 @@ export class ConversationAdapter {
       return this.getProviderForLLM('llm2', config);
     }
     
-    // If it's already a provider name or 'user', return as-is
-    return speaker as LLMProvider;
+    // Validate that it's a valid provider name
+    const validProviders: LLMProvider[] = ['openai', 'anthropic'];
+    if (validProviders.includes(speaker as LLMProvider)) {
+      return speaker as LLMProvider;
+    }
+    
+    throw new Error(`Invalid speaker: ${speaker}. Expected 'llm1', 'llm2', or a valid provider name.`);
   }
   
   /**

--- a/src/conversation-adapter.ts
+++ b/src/conversation-adapter.ts
@@ -1,0 +1,69 @@
+import { Config, LLMIdentifier, LLMProvider } from './types';
+
+/**
+ * ConversationAdapter is responsible for mapping between internal LLM identifiers
+ * (llm1, llm2) and the actual provider names (openai, anthropic) to maintain
+ * compatibility with the visualizer project.
+ */
+export class ConversationAdapter {
+  /**
+   * Maps an internal LLM identifier to its configured provider
+   */
+  static getProviderForLLM(llmId: LLMIdentifier, config: Config): LLMProvider {
+    const providerKey = llmId === 'llm1' ? 'LLM1_PROVIDER' : 'LLM2_PROVIDER';
+    const provider = (config as any)[providerKey] as LLMProvider;
+    
+    if (!provider) {
+      throw new Error(`Provider not configured for ${llmId}`);
+    }
+    
+    return provider;
+  }
+  
+  /**
+   * Transforms internal LLM identifiers to provider names for external output
+   * This is used when saving conversation data to ensure visualizer compatibility
+   */
+  static transformSpeakerForOutput(speaker: string, config: Config): LLMProvider {
+    if (speaker === 'llm1') {
+      return this.getProviderForLLM('llm1', config);
+    } else if (speaker === 'llm2') {
+      return this.getProviderForLLM('llm2', config);
+    }
+    
+    // If it's already a provider name or 'user', return as-is
+    return speaker as LLMProvider;
+  }
+  
+  /**
+   * Gets the model configuration for a specific LLM identifier
+   */
+  static getModelForLLM(llmId: LLMIdentifier, config: Config): string {
+    const provider = this.getProviderForLLM(llmId, config);
+    
+    switch (provider) {
+      case 'openai':
+        return config.OPENAI_MODEL;
+      case 'anthropic':
+        return config.ANTHROPIC_MODEL;
+      default:
+        throw new Error(`Unknown provider: ${provider}`);
+    }
+  }
+  
+  /**
+   * Gets the API base URL for a specific LLM identifier
+   */
+  static getApiBaseForLLM(llmId: LLMIdentifier, config: Config): string {
+    const provider = this.getProviderForLLM(llmId, config);
+    
+    switch (provider) {
+      case 'openai':
+        return config.OPENAI_BASE_URL;
+      case 'anthropic':
+        return config.ANTHROPIC_BASE_URL;
+      default:
+        throw new Error(`Unknown provider: ${provider}`);
+    }
+  }
+}

--- a/src/llm-handler-factory.ts
+++ b/src/llm-handler-factory.ts
@@ -1,0 +1,33 @@
+import { Config, LLMProvider, LLMIdentifier } from './types';
+import { LLMHandler } from './llm-handler-interface';
+import { OpenAIHandler } from './openai-handler';
+import { AnthropicHandler } from './anthropic-handler';
+
+export class LLMHandlerFactory {
+  static createHandler(
+    provider: LLMProvider,
+    config: Config,
+    sessionId: string,
+    turnNumber: number
+  ): LLMHandler {
+    switch (provider) {
+      case 'openai':
+        return new OpenAIHandler(config, sessionId, turnNumber);
+      case 'anthropic':
+        return new AnthropicHandler(config, sessionId, turnNumber);
+      default:
+        throw new Error(`Unsupported LLM provider: ${provider}`);
+    }
+  }
+  
+  static getProviderForLLM(llmId: LLMIdentifier, config: Config): LLMProvider {
+    const providerKey = llmId === 'llm1' ? 'LLM1_PROVIDER' : 'LLM2_PROVIDER';
+    const provider = (config as any)[providerKey] as LLMProvider;
+    
+    if (!provider) {
+      throw new Error(`Provider not configured for ${llmId}`);
+    }
+    
+    return provider;
+  }
+}

--- a/src/llm-handler-factory.ts
+++ b/src/llm-handler-factory.ts
@@ -2,6 +2,7 @@ import { Config, LLMProvider, LLMIdentifier } from './types';
 import { LLMHandler } from './llm-handler-interface';
 import { OpenAIHandler } from './openai-handler';
 import { AnthropicHandler } from './anthropic-handler';
+import { ConversationAdapter } from './conversation-adapter';
 
 export class LLMHandlerFactory {
   static createHandler(
@@ -21,13 +22,6 @@ export class LLMHandlerFactory {
   }
   
   static getProviderForLLM(llmId: LLMIdentifier, config: Config): LLMProvider {
-    const providerKey = llmId === 'llm1' ? 'LLM1_PROVIDER' : 'LLM2_PROVIDER';
-    const provider = (config as any)[providerKey] as LLMProvider;
-    
-    if (!provider) {
-      throw new Error(`Provider not configured for ${llmId}`);
-    }
-    
-    return provider;
+    return ConversationAdapter.getProviderForLLM(llmId, config);
   }
 }

--- a/src/llm-handler-interface.ts
+++ b/src/llm-handler-interface.ts
@@ -1,0 +1,5 @@
+import { AIHandlerResult } from './types';
+
+export interface LLMHandler {
+  processMessage(message: string, sessionId: string, turnNumber: number): Promise<AIHandlerResult>;
+}

--- a/src/openai-handler.ts
+++ b/src/openai-handler.ts
@@ -4,8 +4,9 @@ import { Config, OpenAIResponse, TurnMetadata, AIHandlerResult } from './types';
 import { Logger } from './logger';
 import { HistoryManager } from './history';
 import { withRetry, DEFAULT_RETRY_OPTIONS } from './retry-utils';
+import { LLMHandler } from './llm-handler-interface';
 
-export class OpenAIHandler {
+export class OpenAIHandler implements LLMHandler {
   private config: Config;
   private logger: Logger;
   private historyManager: HistoryManager;

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+
+/**
+ * Basic tests for configurable LLM providers functionality
+ * Run with: npx tsx src/tests.ts
+ */
+
+import { LLMHandlerFactory } from './llm-handler-factory';
+import { ConversationAdapter } from './conversation-adapter';
+import { Config, LLMProvider, LLMIdentifier } from './types';
+
+// Mock configuration for testing
+const mockConfig: Config = {
+  LLM1_PROVIDER: 'openai' as LLMProvider,
+  LLM2_PROVIDER: 'anthropic' as LLMProvider,
+  OPENAI_API_KEY: 'test-key',
+  OPENAI_MODEL: 'gpt-4',
+  OPENAI_BASE_URL: 'https://api.openai.com/v1',
+  ANTHROPIC_API_KEY: 'test-key',
+  ANTHROPIC_MODEL: 'claude-3-5-sonnet',
+  ANTHROPIC_BASE_URL: 'https://api.anthropic.com/v1',
+  CONVERSATION_TOPIC: 'Test topic',
+  MAX_TURNS: '4',
+  DELAY_BETWEEN_MESSAGES: '1'
+};
+
+function runTests() {
+  console.log('🧪 Running basic tests for configurable LLM providers...\n');
+  
+  let passed = 0;
+  let failed = 0;
+  
+  function test(name: string, testFn: () => void) {
+    try {
+      testFn();
+      console.log(`✅ ${name}`);
+      passed++;
+    } catch (error) {
+      console.log(`❌ ${name}: ${error}`);
+      failed++;
+    }
+  }
+  
+  // Test ConversationAdapter.getProviderForLLM
+  test('ConversationAdapter.getProviderForLLM - llm1 returns openai', () => {
+    const result = ConversationAdapter.getProviderForLLM('llm1', mockConfig);
+    if (result !== 'openai') throw new Error(`Expected 'openai', got '${result}'`);
+  });
+  
+  test('ConversationAdapter.getProviderForLLM - llm2 returns anthropic', () => {
+    const result = ConversationAdapter.getProviderForLLM('llm2', mockConfig);
+    if (result !== 'anthropic') throw new Error(`Expected 'anthropic', got '${result}'`);
+  });
+  
+  // Test LLMHandlerFactory delegation
+  test('LLMHandlerFactory.getProviderForLLM delegates to ConversationAdapter', () => {
+    const result1 = LLMHandlerFactory.getProviderForLLM('llm1', mockConfig);
+    const result2 = ConversationAdapter.getProviderForLLM('llm1', mockConfig);
+    if (result1 !== result2) throw new Error('Factory does not delegate properly');
+  });
+  
+  // Test ConversationAdapter.transformSpeakerForOutput
+  test('ConversationAdapter.transformSpeakerForOutput - llm1 transforms to openai', () => {
+    const result = ConversationAdapter.transformSpeakerForOutput('llm1', mockConfig);
+    if (result !== 'openai') throw new Error(`Expected 'openai', got '${result}'`);
+  });
+  
+  test('ConversationAdapter.transformSpeakerForOutput - valid provider passthrough', () => {
+    const result = ConversationAdapter.transformSpeakerForOutput('anthropic', mockConfig);
+    if (result !== 'anthropic') throw new Error(`Expected 'anthropic', got '${result}'`);
+  });
+  
+  test('ConversationAdapter.transformSpeakerForOutput - invalid speaker throws error', () => {
+    try {
+      ConversationAdapter.transformSpeakerForOutput('invalid', mockConfig);
+      throw new Error('Should have thrown an error');
+    } catch (error) {
+      if (!(error instanceof Error) || !error.message.includes('Invalid speaker')) {
+        throw new Error('Wrong error message');
+      }
+    }
+  });
+  
+  // Test ConversationAdapter.getModelForLLM
+  test('ConversationAdapter.getModelForLLM - llm1 returns OpenAI model', () => {
+    const result = ConversationAdapter.getModelForLLM('llm1', mockConfig);
+    if (result !== 'gpt-4') throw new Error(`Expected 'gpt-4', got '${result}'`);
+  });
+  
+  test('ConversationAdapter.getModelForLLM - llm2 returns Anthropic model', () => {
+    const result = ConversationAdapter.getModelForLLM('llm2', mockConfig);
+    if (result !== 'claude-3-5-sonnet') throw new Error(`Expected 'claude-3-5-sonnet', got '${result}'`);
+  });
+  
+  // Test ConversationAdapter.getApiBaseForLLM
+  test('ConversationAdapter.getApiBaseForLLM - llm1 returns OpenAI base URL', () => {
+    const result = ConversationAdapter.getApiBaseForLLM('llm1', mockConfig);
+    if (result !== 'https://api.openai.com/v1') throw new Error(`Expected OpenAI URL, got '${result}'`);
+  });
+  
+  // Test LLMHandlerFactory.createHandler
+  test('LLMHandlerFactory.createHandler - creates OpenAI handler', () => {
+    const handler = LLMHandlerFactory.createHandler('openai', mockConfig, 'test-session', 1);
+    if (!handler) throw new Error('Handler not created');
+    if (handler.constructor.name !== 'OpenAIHandler') throw new Error('Wrong handler type');
+  });
+  
+  test('LLMHandlerFactory.createHandler - creates Anthropic handler', () => {
+    const handler = LLMHandlerFactory.createHandler('anthropic', mockConfig, 'test-session', 1);
+    if (!handler) throw new Error('Handler not created');
+    if (handler.constructor.name !== 'AnthropicHandler') throw new Error('Wrong handler type');
+  });
+  
+  test('LLMHandlerFactory.createHandler - throws error for invalid provider', () => {
+    try {
+      LLMHandlerFactory.createHandler('invalid' as LLMProvider, mockConfig, 'test-session', 1);
+      throw new Error('Should have thrown an error');
+    } catch (error) {
+      if (!(error instanceof Error) || !error.message.includes('Unsupported LLM provider')) {
+        throw new Error('Wrong error message');
+      }
+    }
+  });
+  
+  // Test provider configuration validation
+  test('ConversationAdapter handles mixed provider configuration', () => {
+    const mixedConfig: Config = {
+      ...mockConfig,
+      LLM1_PROVIDER: 'anthropic' as LLMProvider,
+      LLM2_PROVIDER: 'openai' as LLMProvider
+    };
+    
+    const llm1Provider = ConversationAdapter.getProviderForLLM('llm1', mixedConfig);
+    const llm2Provider = ConversationAdapter.getProviderForLLM('llm2', mixedConfig);
+    
+    if (llm1Provider !== 'anthropic') throw new Error('LLM1 should be anthropic');
+    if (llm2Provider !== 'openai') throw new Error('LLM2 should be openai');
+  });
+  
+  // Summary
+  console.log(`\n📊 Test Results: ${passed} passed, ${failed} failed`);
+  
+  if (failed > 0) {
+    console.log('❌ Some tests failed!');
+    process.exit(1);
+  } else {
+    console.log('✅ All tests passed!');
+  }
+}
+
+if (require.main === module) {
+  runTests();
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,10 @@
+export type LLMProvider = 'openai' | 'anthropic';
+export type LLMIdentifier = 'llm1' | 'llm2';
+
 export interface Config {
   // LLM Provider Configuration
-  LLM1_PROVIDER: string;
-  LLM2_PROVIDER: string;
+  LLM1_PROVIDER: LLMProvider;
+  LLM2_PROVIDER: LLMProvider;
   
   // OpenAI Configuration
   OPENAI_API_KEY: string;
@@ -26,9 +29,6 @@ export interface Config {
   UPLOAD_MAX_RETRIES?: string;
   UPLOAD_RETRY_DELAY?: string;
 }
-
-export type LLMProvider = 'openai' | 'anthropic';
-export type LLMIdentifier = 'llm1' | 'llm2';
 
 export interface ConversationMessage {
   role?: 'user' | 'assistant' | 'system';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,14 +1,24 @@
 export interface Config {
+  // LLM Provider Configuration
+  LLM1_PROVIDER: string;
+  LLM2_PROVIDER: string;
+  
+  // OpenAI Configuration
   OPENAI_API_KEY: string;
-  ANTHROPIC_API_KEY: string;
   OPENAI_MODEL: string;
-  ANTHROPIC_MODEL: string;
   OPENAI_BASE_URL: string;
+  
+  // Anthropic Configuration
+  ANTHROPIC_API_KEY: string;
+  ANTHROPIC_MODEL: string;
   ANTHROPIC_BASE_URL: string;
+  
+  // Conversation Settings
   CONVERSATION_TOPIC: string;
   MAX_TURNS: string;
   DELAY_BETWEEN_MESSAGES: string;
   LOG_LEVEL?: string;
+  
   // Upload Settings
   UPLOAD_ENABLED?: string;
   UPLOAD_API_URL?: string;
@@ -17,10 +27,13 @@ export interface Config {
   UPLOAD_RETRY_DELAY?: string;
 }
 
+export type LLMProvider = 'openai' | 'anthropic';
+export type LLMIdentifier = 'llm1' | 'llm2';
+
 export interface ConversationMessage {
   role?: 'user' | 'assistant' | 'system';
   content: string;
-  speaker?: 'openai' | 'anthropic';
+  speaker?: LLMProvider;
 }
 
 export interface ConversationHistory {
@@ -38,7 +51,7 @@ export interface TokenUsage {
 
 export interface TurnMetadata {
   turn: number;
-  speaker: 'openai' | 'anthropic';
+  speaker: LLMProvider;
   model: string;
   timestamp: string;
   input: string;
@@ -80,8 +93,9 @@ export interface ComprehensiveConversation {
   metadata: ConversationMetadata;
   conversation: ConversationData;
   models: {
-    openai: ModelInfo;
-    anthropic: ModelInfo;
+    openai?: ModelInfo;
+    anthropic?: ModelInfo;
+    [key: string]: ModelInfo | undefined;
   };
   statistics: ConversationStatistics;
   turns: TurnMetadata[];

--- a/src/upload-service.ts
+++ b/src/upload-service.ts
@@ -28,7 +28,11 @@ export class UploadService {
    */
   async testConnection(): Promise<boolean> {
     try {
-      const url = new URL(this.config.UPLOAD_API_URL);
+      const uploadUrl = this.config.UPLOAD_API_URL;
+      if (!uploadUrl) {
+        return false;
+      }
+      const url = new URL(uploadUrl);
       
       return new Promise((resolve) => {
         const options = {
@@ -41,7 +45,7 @@ export class UploadService {
 
         const req = https.request(options, (res) => {
           // Any response (even 405 Method Not Allowed) means the endpoint is reachable
-          resolve(res.statusCode < 500);
+          resolve(res.statusCode !== undefined && res.statusCode < 500);
         });
 
         req.on('error', () => resolve(false));
@@ -130,7 +134,11 @@ export class UploadService {
   private async _performUpload(conversation: ComprehensiveConversation, filename?: string): Promise<UploadResult> {
     return new Promise((resolve, reject) => {
       try {
-        const url = new URL(this.config.UPLOAD_API_URL);
+        const uploadUrl = this.config.UPLOAD_API_URL;
+        if (!uploadUrl) {
+          throw new Error('Upload API URL not configured');
+        }
+        const url = new URL(uploadUrl);
         const data = JSON.stringify(conversation);
         
         const options = {

--- a/src/upload-service.ts
+++ b/src/upload-service.ts
@@ -124,8 +124,8 @@ export class UploadService {
    * Generate viewer URL from filename
    */
   generateViewerUrl(filename: string): string {
-    const cleanFilename = path.basename(filename);
-    return `https://modelstogether.com/conversation/${cleanFilename}`;
+    const cleanFilename = path.basename(filename, '.json');
+    return `https://modelstogether.com/conversation/${cleanFilename}.json`;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Added support for configurable LLM providers through `LLM1_PROVIDER` and `LLM2_PROVIDER` settings
- Users can now choose which provider (OpenAI or Anthropic) to use for each LLM in the conversation
- Maintains backward compatibility with the visualizer project at `../llm-conversation-visualizer`

## Changes

### Configuration Updates
- Added `LLM1_PROVIDER` and `LLM2_PROVIDER` to specify which provider to use for each LLM
- Provider-specific API keys remain unchanged (OPENAI_API_KEY, ANTHROPIC_API_KEY)
- Updated `config.env.example` with new configuration structure

### Architecture Improvements
- Created `LLMHandler` interface for better abstraction
- Implemented factory pattern with `LLMHandlerFactory` for dynamic handler instantiation
- Added type definitions `LLMProvider` and `LLMIdentifier`
- Created `ConversationAdapter` for future mapping needs

### Code Updates
- Updated conversation flow to use factory pattern
- Modified handlers to implement the common interface
- Updated types to support flexible provider configuration
- Fixed TypeScript errors in upload-service.ts

### Documentation
- Updated README with new configuration instructions
- Added examples of different provider combinations

## Benefits
Users can now:
- Use two OpenAI models talking to each other
- Use two Anthropic models talking to each other
- Mix and match providers as desired
- Easily add new providers in the future

## Test Plan
- [x] TypeScript compilation passes (`npm run type-check`)
- [x] Project builds successfully (`npm run build`)
- [ ] Test with OpenAI <-> Anthropic configuration (default)
- [ ] Test with OpenAI <-> OpenAI configuration
- [ ] Test with Anthropic <-> Anthropic configuration
- [ ] Verify visualizer compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)