### PR TITLE
feat: Add visualizer integration with speaker alternation support

### DIFF
--- a/src/anthropic-handler.ts
+++ b/src/anthropic-handler.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { Config, AnthropicResponse, TurnMetadata, AIHandlerResult } from './types';
+import { Config, AnthropicResponse, TurnMetadata, AIHandlerResult, SpeakerPosition } from './types';
 import { Logger } from './logger';
 import { HistoryManager } from './history';
 import { withRetry, DEFAULT_RETRY_OPTIONS } from './retry-utils';
@@ -11,10 +11,12 @@ export class AnthropicHandler implements LLMHandler {
   private logger: Logger;
   private historyManager: HistoryManager;
   private model: string;
+  private speakerPosition: SpeakerPosition;
   
-  constructor(config: Config, sessionId: string, turnNumber: number, model?: string) {
+  constructor(config: Config, sessionId: string, turnNumber: number, speakerPosition: SpeakerPosition, model?: string) {
     this.config = config;
     this.model = model || config.ANTHROPIC_MODEL;
+    this.speakerPosition = speakerPosition;
     
     const logDir = path.join(process.cwd(), 'logs');
     const anthropicLog = path.join(logDir, `${sessionId}_anthropic.log`);
@@ -100,7 +102,7 @@ export class AnthropicHandler implements LLMHandler {
       // Create metadata
       const metadata: TurnMetadata = {
         turn: turnNumber,
-        speaker: 'anthropic',
+        speaker: this.speakerPosition,
         model: modelUsed,
         timestamp: new Date().toISOString(),
         input: message,

--- a/src/conversation.ts
+++ b/src/conversation.ts
@@ -84,7 +84,12 @@ function createComprehensiveJson(
       duration_seconds: duration,
       status: 'completed',
       version: '2.0',
-      features: ['conversation_history', 'context_aware', 'typescript_native']
+      features: ['conversation_history', 'context_aware', 'typescript_native'],
+      // LLM configuration for visualizer integration
+      llm1_provider: llm1Provider,
+      llm1_model: llm1Model,
+      llm2_provider: llm2Provider,
+      llm2_model: llm2Model
     },
     conversation: {
       topic,

--- a/src/conversation.ts
+++ b/src/conversation.ts
@@ -15,7 +15,7 @@ function generateSessionId(topic: string): string {
   return `conversation_${timestamp}_${topicSlug}`;
 }
 
-function collectTurnData(logDir: string, sessionId: string): {
+function collectTurnData(logDir: string, sessionId: string, llm1Provider: LLMProvider, llm2Provider: LLMProvider): {
   turns: TurnMetadata[];
   totalTokens: number;
   openaiTokens: number;
@@ -38,11 +38,19 @@ function collectTurnData(logDir: string, sessionId: string): {
       const tokens = turnData.tokens?.total || 0;
       totalTokens += tokens;
       
-      // Still track by provider for statistics
-      if (turnData.speaker === 'openai') {
-        openaiTokens += tokens;
-      } else if (turnData.speaker === 'anthropic') {
-        anthropicTokens += tokens;
+      // Track by provider for statistics using speaker position mapping
+      if (turnData.speaker === 'speaker_1') {
+        if (llm1Provider === 'openai') {
+          openaiTokens += tokens;
+        } else if (llm1Provider === 'anthropic') {
+          anthropicTokens += tokens;
+        }
+      } else if (turnData.speaker === 'speaker_2') {
+        if (llm2Provider === 'openai') {
+          openaiTokens += tokens;
+        } else if (llm2Provider === 'anthropic') {
+          anthropicTokens += tokens;
+        }
       }
     } catch (error) {
       console.error(`Error reading ${turnFile}:`, error);
@@ -248,7 +256,7 @@ async function main() {
     logger.log('INFO', 'Building comprehensive JSON export...');
     
     // Collect turn data and create comprehensive JSON
-    const { turns, totalTokens, openaiTokens, anthropicTokens } = collectTurnData(logDir, sessionId);
+    const { turns, totalTokens, openaiTokens, anthropicTokens } = collectTurnData(logDir, sessionId, llm1Provider, llm2Provider);
     
     const jsonOutput = createComprehensiveJson(
       sessionId,

--- a/src/enhanced-config.ts
+++ b/src/enhanced-config.ts
@@ -33,7 +33,7 @@ export async function loadEnhancedConfig(options: ConfigOptions = {}): Promise<C
     const trimmedLine = line.trim();
     if (trimmedLine && !trimmedLine.startsWith('#') && trimmedLine.includes('=')) {
       const [key, ...valueParts] = trimmedLine.split('=');
-      const value = valueParts.join('=').trim();
+      const value = valueParts.join('=').replace(/^["']|["']$/g, '');
       (config as any)[key.trim()] = value;
     }
   }

--- a/src/integration-tests.ts
+++ b/src/integration-tests.ts
@@ -200,7 +200,7 @@ function runIntegrationTests() {
     const config = createMockConfig();
     
     // Test direct handler creation with model parameter
-    const handler = LLMHandlerFactory.createHandler('openai', config, 'test-session', 1, 'gpt-3.5-turbo');
+    const handler = LLMHandlerFactory.createHandler('openai', config, 'test-session', 1, 'speaker_1', 'gpt-3.5-turbo');
     
     if (!handler) throw new Error('Handler should be created');
     if (handler.constructor.name !== 'OpenAIHandler') {
@@ -212,7 +212,7 @@ function runIntegrationTests() {
     const config = createMockConfig();
     
     try {
-      LLMHandlerFactory.createHandler('invalid' as any, config, 'test-session', 1);
+      LLMHandlerFactory.createHandler('invalid' as any, config, 'test-session', 1, 'speaker_1');
       throw new Error('Should have thrown error for invalid provider');
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);

--- a/src/llm-handler-factory.ts
+++ b/src/llm-handler-factory.ts
@@ -1,4 +1,4 @@
-import { Config, LLMProvider, LLMIdentifier } from './types';
+import { Config, LLMProvider, LLMIdentifier, SpeakerPosition } from './types';
 import { LLMHandler } from './llm-handler-interface';
 import { OpenAIHandler } from './openai-handler';
 import { AnthropicHandler } from './anthropic-handler';
@@ -10,13 +10,14 @@ export class LLMHandlerFactory {
     config: Config,
     sessionId: string,
     turnNumber: number,
+    speakerPosition: SpeakerPosition,
     model?: string
   ): LLMHandler {
     switch (provider) {
       case 'openai':
-        return new OpenAIHandler(config, sessionId, turnNumber, model);
+        return new OpenAIHandler(config, sessionId, turnNumber, speakerPosition, model);
       case 'anthropic':
-        return new AnthropicHandler(config, sessionId, turnNumber, model);
+        return new AnthropicHandler(config, sessionId, turnNumber, speakerPosition, model);
       default:
         throw new Error(`Unsupported LLM provider: ${provider}`);
     }
@@ -30,10 +31,16 @@ export class LLMHandlerFactory {
   ): LLMHandler {
     const provider = this.getProviderForLLM(llmId, config);
     const model = ConversationAdapter.getModelForLLM(llmId, config);
-    return this.createHandler(provider, config, sessionId, turnNumber, model);
+    const speakerPosition = this.getSpeakerPositionForLLM(llmId);
+    return this.createHandler(provider, config, sessionId, turnNumber, speakerPosition, model);
   }
   
   static getProviderForLLM(llmId: LLMIdentifier, config: Config): LLMProvider {
     return ConversationAdapter.getProviderForLLM(llmId, config);
+  }
+  
+  static getSpeakerPositionForLLM(llmId: LLMIdentifier): SpeakerPosition {
+    // Map LLM identifiers to speaker positions for visual alternation
+    return llmId === 'llm1' ? 'speaker_1' : 'speaker_2';
   }
 }

--- a/src/openai-handler.ts
+++ b/src/openai-handler.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { Config, OpenAIResponse, TurnMetadata, AIHandlerResult } from './types';
+import { Config, OpenAIResponse, TurnMetadata, AIHandlerResult, SpeakerPosition } from './types';
 import { Logger } from './logger';
 import { HistoryManager } from './history';
 import { withRetry, DEFAULT_RETRY_OPTIONS } from './retry-utils';
@@ -11,10 +11,12 @@ export class OpenAIHandler implements LLMHandler {
   private logger: Logger;
   private historyManager: HistoryManager;
   private model: string;
+  private speakerPosition: SpeakerPosition;
   
-  constructor(config: Config, sessionId: string, turnNumber: number, model?: string) {
+  constructor(config: Config, sessionId: string, turnNumber: number, speakerPosition: SpeakerPosition, model?: string) {
     this.config = config;
     this.model = model || config.OPENAI_MODEL;
+    this.speakerPosition = speakerPosition;
     
     const logDir = path.join(process.cwd(), 'logs');
     const openaiLog = path.join(logDir, `${sessionId}_openai.log`);
@@ -99,7 +101,7 @@ export class OpenAIHandler implements LLMHandler {
       // Create metadata
       const metadata: TurnMetadata = {
         turn: turnNumber,
-        speaker: 'openai',
+        speaker: this.speakerPosition,
         model: modelUsed,
         timestamp: new Date().toISOString(),
         input: message,

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -100,26 +100,37 @@ function runTests() {
   
   // Test LLMHandlerFactory.createHandler
   test('LLMHandlerFactory.createHandler - creates OpenAI handler', () => {
-    const handler = LLMHandlerFactory.createHandler('openai', mockConfig, 'test-session', 1);
+    const handler = LLMHandlerFactory.createHandler('openai', mockConfig, 'test-session', 1, 'speaker_1');
     if (!handler) throw new Error('Handler not created');
     if (handler.constructor.name !== 'OpenAIHandler') throw new Error('Wrong handler type');
   });
   
   test('LLMHandlerFactory.createHandler - creates Anthropic handler', () => {
-    const handler = LLMHandlerFactory.createHandler('anthropic', mockConfig, 'test-session', 1);
+    const handler = LLMHandlerFactory.createHandler('anthropic', mockConfig, 'test-session', 1, 'speaker_2');
     if (!handler) throw new Error('Handler not created');
     if (handler.constructor.name !== 'AnthropicHandler') throw new Error('Wrong handler type');
   });
   
   test('LLMHandlerFactory.createHandler - throws error for invalid provider', () => {
     try {
-      LLMHandlerFactory.createHandler('invalid' as LLMProvider, mockConfig, 'test-session', 1);
+      LLMHandlerFactory.createHandler('invalid' as LLMProvider, mockConfig, 'test-session', 1, 'speaker_1');
       throw new Error('Should have thrown an error');
     } catch (error) {
       if (!(error instanceof Error) || !error.message.includes('Unsupported LLM provider')) {
         throw new Error('Wrong error message');
       }
     }
+  });
+  
+  // Test speaker position mapping
+  test('LLMHandlerFactory.getSpeakerPositionForLLM - llm1 maps to speaker_1', () => {
+    const result = LLMHandlerFactory.getSpeakerPositionForLLM('llm1');
+    if (result !== 'speaker_1') throw new Error(`Expected 'speaker_1', got '${result}'`);
+  });
+  
+  test('LLMHandlerFactory.getSpeakerPositionForLLM - llm2 maps to speaker_2', () => {
+    const result = LLMHandlerFactory.getSpeakerPositionForLLM('llm2');
+    if (result !== 'speaker_2') throw new Error(`Expected 'speaker_2', got '${result}'`);
   });
   
   // Test provider configuration validation

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 export type LLMProvider = 'openai' | 'anthropic';
 export type LLMIdentifier = 'llm1' | 'llm2';
+export type SpeakerPosition = 'speaker_1' | 'speaker_2';
 
 export interface Config {
   // LLM Provider Configuration
@@ -55,7 +56,7 @@ export interface TokenUsage {
 
 export interface TurnMetadata {
   turn: number;
-  speaker: LLMProvider;
+  speaker: SpeakerPosition; // Changed from LLMProvider to SpeakerPosition for visual alternation
   model: string;
   timestamp: string;
   input: string;
@@ -73,6 +74,11 @@ export interface ConversationMetadata {
   status: 'completed' | 'failed' | 'in_progress';
   version: string;
   features: string[];
+  // LLM configuration metadata for visualizer integration
+  llm1_provider?: string;
+  llm1_model?: string;
+  llm2_provider?: string;
+  llm2_model?: string;
 }
 
 export interface ConversationStatistics {


### PR DESCRIPTION
## Summary

Implement provider-agnostic speaker alternation to properly display conversations with any provider combination in the visualizer. This integrates with [llm-conversation-visualizer PR #13](https://github.com/myleshenderson/llm-conversation-visualizer/pull/13).

## Problem

After multi-model support was added, conversations with the same provider (e.g., two Claude models) display all messages on the same side in the visualizer instead of alternating left/right. The visualizer needs `speaker_1`/`speaker_2` format instead of provider names for proper visual alternation.

## Solution

### Speaker Position System
- Map LLM1 → `speaker_1`, LLM2 → `speaker_2` for visual alternation  
- Update `TurnMetadata.speaker` to use `SpeakerPosition` instead of `LLMProvider`
- Add `getSpeakerPositionForLLM()` method to `LLMHandlerFactory`

### Enhanced JSON Export Format
- Add `llm1_provider`, `llm1_model`, `llm2_provider`, `llm2_model` to metadata
- Maintain existing `models` section for backward compatibility
- Update `ConversationMetadata` interface with new fields

### Handler Updates
- Update `OpenAIHandler` and `AnthropicHandler` constructors to accept `SpeakerPosition`
- Modify `LLMHandlerFactory.createHandler()` signature for speaker position
- Update `conversation.ts` to pass speaker positions to handlers

### Configuration Fix  
- Fix quote parsing in `enhanced-config.ts` to match `config.ts` behavior
- Ensure proper handling of quoted config values from dynamic discovery

## Changes

- **src/types.ts**: Add `SpeakerPosition` type and update `ConversationMetadata`
- **src/llm-handler-factory.ts**: Add speaker position mapping logic
- **src/anthropic-handler.ts**: Accept speaker position in constructor
- **src/openai-handler.ts**: Accept speaker position in constructor  
- **src/conversation.ts**: Add metadata fields for visualizer integration
- **src/enhanced-config.ts**: Fix quote parsing to match config.ts
- **src/tests.ts**: Update tests for new handler signatures
- **src/integration-tests.ts**: Update integration tests

## Benefits

- ✅ Works with any provider combination (2 Claude models, 2 GPT models, mixed)
- ✅ Proper left/right visual alternation in visualizer regardless of providers
- ✅ Provider-agnostic solution not tied to "openai" or "anthropic" names
- ✅ Backward compatible with existing conversations in visualizer
- ✅ Ready for integration with visualizer PR #13

## Example Output

```json
{
  "metadata": {
    "llm1_provider": "anthropic",
    "llm1_model": "claude-3-5-sonnet-20241022",
    "llm2_provider": "anthropic",
    "llm2_model": "claude-3-5-sonnet-20241022"
  },
  "turns": [
    {"turn": 1, "speaker": "speaker_1", "model": "claude-3-5-sonnet-20241022"},
    {"turn": 2, "speaker": "speaker_2", "model": "claude-3-5-sonnet-20241022"}
  ]
}
```

## Test Plan

- [x] All existing tests pass (15/15)
- [x] Type checking passes without errors
- [x] Speaker alternation works: `speaker_1`, `speaker_2`, `speaker_1`, `speaker_2`
- [x] Metadata includes expected visualizer format
- [x] Integration tested with visualizer CSS classes
- [x] Works with same provider (2 Claude models) and mixed providers

## Next Steps

Once this PR is merged and visualizer PR #13 is merged, conversations will display with proper visual alternation regardless of provider combination.

🤖 Generated with [Claude Code](https://claude.ai/code)